### PR TITLE
Handle case where data may not be present

### DIFF
--- a/src/main/java/br/edu/ifpr/persistencia/core/Query.java
+++ b/src/main/java/br/edu/ifpr/persistencia/core/Query.java
@@ -1,6 +1,8 @@
 package br.edu.ifpr.persistencia.core;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.UUID;
 import java.util.function.Function;
 import java.util.function.Predicate;
@@ -8,7 +10,11 @@ import java.util.stream.Collectors;
 
 public class Query<T> {
 
-    private Map<UUID, T> data;
+    private Map<UUID, T> data = new LinkedHashMap<>();
+
+    private Query() {
+
+    }
 
 	public Query(Map<UUID, T> data) {
 		this.data = data;
@@ -19,7 +25,10 @@ public class Query<T> {
     }
 
     public Query<T> is(UUID id) {
-        return new Query<>(Map.of(id, data.get(id)));
+        return Optional.ofNullable(data.get(id)).map(entity -> {
+            data = Map.of(id, entity);
+            return this;
+        }).orElse(new Query<>());
     }
 
     public Query<T> is(Predicate<T> predicate) {

--- a/src/main/java/br/edu/ifpr/persistencia/interfaces/Identifiable.java
+++ b/src/main/java/br/edu/ifpr/persistencia/interfaces/Identifiable.java
@@ -4,8 +4,10 @@ import java.util.UUID;
 
 public interface Identifiable {
 
+    UUID id = UUID.randomUUID();
+
     default UUID getId() {
-        return UUID.randomUUID();
+        return id;
     }
 
 }


### PR DESCRIPTION
When the data is not present, simply return an empty Query<T> instead of crashing on NullPointerException.